### PR TITLE
Change source_base_url.

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -33,7 +33,7 @@ module Mastodon
     end
 
     def source_base_url
-      'https://github.com/tootsuite/mastodon'
+      'https://github.com/kedamaDQ/mastodon'
     end
 
     # specify git tag or commit hash here


### PR DESCRIPTION
Change source_base_url from tootsuite/mastodon to kedamaDQ/mastodon.
ソースコードリンクの参照先を独自リポジトリの url に変更します。