### PR TITLE
Extend some attachment restrictions.

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -32,7 +32,7 @@ class MediaAttachment < ApplicationRecord
   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'].freeze
   VIDEO_MIME_TYPES = ['video/webm', 'video/mp4'].freeze
 
-  IMAGE_STYLES = { original: '1280x1280>', small: '400x400>' }.freeze
+  IMAGE_STYLES = { original: '1920x1920>', small: '400x400>' }.freeze
   VIDEO_STYLES = {
     small: {
       convert_options: {
@@ -56,7 +56,7 @@ class MediaAttachment < ApplicationRecord
   include Remotable
 
   validates_attachment_content_type :file, content_type: IMAGE_MIME_TYPES + VIDEO_MIME_TYPES
-  validates_attachment_size :file, less_than: 8.megabytes
+  validates_attachment_size :file, less_than: 24.megabytes
 
   validates :account, presence: true
   validates :description, length: { maximum: 420 }, if: :local?


### PR DESCRIPTION
- Extends size of attachment file from 8mb to 24mb.
- 添付する画像や動画のサイズ制限を 8mb から 24mb に拡張します。
- Extends size of attachment image from 1280 pixels square to 1920 pixels square.
- 添付する画像のサイズ制限を 1280px 平方から 1920px(fullHD) 平方に拡張します。