### PR TITLE
Emoji suggestion works with forward matching.

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_mart_search_light.js
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_search_light.js
@@ -54,6 +54,17 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
       return [emojisList['-1']];
     }
 
+    if (value.match(/^[a-z]_/i)) {
+      const regExp = new RegExp(`^${value}`, 'i');
+      const matches = Object.keys(emojisList).map((emoji_id) => {
+        if (regexp.test(emoji_id)) {
+          return emojisList[emoji_id];
+        }
+      }).filter((a) => a);
+
+      return matches.slice(0, maxResults);
+    }
+
     let values = value.toLowerCase().split(/[\s|,|\-|_]+/),
       allResults = [];
 


### PR DESCRIPTION
- Emoji suggestion works with forward matching if shortcode starts with `^[a-z]_`.
- 入力されたショートコードの先頭2文字が「アルファベット１文字 + '_'」であった場合に限り、絵文字の候補をショートコードの前方一致で検索します。