### PR TITLE
Focus to spoiler text when click "CW" button.

### DIFF
--- a/app/javascript/mastodon/components/collapsable.js
+++ b/app/javascript/mastodon/components/collapsable.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 const Collapsable = ({ fullHeight, isVisible, children }) => (
   <Motion defaultStyle={{ opacity: !isVisible ? 0 : 100, height: isVisible ? fullHeight : 0 }} style={{ opacity: spring(!isVisible ? 0 : 100), height: spring(!isVisible ? 0 : fullHeight) }}>
     {({ opacity, height }) => (
-      <div style={{ height: `${height}px`, overflow: 'hidden', opacity: opacity / 100, display: Math.floor(opacity) === 0 ? 'none' : 'block' }}>
+      <div style={{ height: `${height}px`, overflow: 'hidden', opacity: opacity / 100, display: 'block' }}>
         {children}
       </div>
     )}

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -104,6 +104,12 @@ export default class ComposeForm extends ImmutablePureComponent {
     this.props.onChangeSpoilerText(e.target.value);
   }
 
+  handleClickSpoilerButton = () => {
+    if (!this.props.spoiler) {
+      this.spoilerInput.focus();
+    }
+  }
+
   componentDidUpdate (prevProps) {
     // This statement does several things:
     // - If we're beginning a reply, and,
@@ -133,6 +139,10 @@ export default class ComposeForm extends ImmutablePureComponent {
 
   setAutosuggestTextarea = (c) => {
     this.autosuggestTextarea = c;
+  }
+
+  setSpoilerText = (c) => {
+    this.spoilerInput = c;
   }
 
   handleEmojiPick = (data) => {
@@ -166,7 +176,7 @@ export default class ComposeForm extends ImmutablePureComponent {
           <div className='spoiler-input'>
             <label>
               <span style={{ display: 'none' }}>{intl.formatMessage(messages.spoiler_placeholder)}</span>
-              <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type='text' className='spoiler-input__input'  id='cw-spoiler-input' />
+              <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type='text' className='spoiler-input__input'  id='cw-spoiler-input' ref={this.setSpoilerText} />
             </label>
           </div>
         </Collapsable>
@@ -201,7 +211,9 @@ export default class ComposeForm extends ImmutablePureComponent {
             <UploadButtonContainer />
             <PrivacyDropdownContainer />
             <SensitiveButtonContainer />
-            <SpoilerButtonContainer />
+            <SpoilerButtonContainer
+              onClick={this.handleClickSpoilerButton}
+            />
           </div>
           <div className='character-counter__wrapper'><CharacterCounter max={500} text={text} /></div>
         </div>

--- a/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
@@ -15,10 +15,11 @@ const mapStateToProps = (state, { intl }) => ({
   ariaControls: 'cw-spoiler-input',
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch, ownProps) => ({
 
   onClick () {
     dispatch(changeComposeSpoilerness());
+    ownProps.onClick();
   },
 
 });


### PR DESCRIPTION
This is a crude implementation, but very useful.
- Collapsible component is 0 height block if collapsed.(Not "display: none;")
- Not focus back to AutoSuggestTextarea even if collapse SpoilerText.