### PR TITLE
Add local timeline to initial display columns.

### DIFF
--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -84,6 +84,7 @@ const defaultColumns = fromJS([
   { id: 'COMPOSE', uuid: uuid(), params: {} },
   { id: 'HOME', uuid: uuid(), params: {} },
   { id: 'NOTIFICATIONS', uuid: uuid(), params: {} },
+  { id: 'COMMUNITY', uuid: uuid(), params: {} },
 ]);
 
 const hydrate = (state, settings) => state.mergeDeep(settings).update('columns', (val = defaultColumns) => val);


### PR DESCRIPTION
When new user logins to the foresdon, there are compose, home, and notifications. And the home timeline is filled up by my posts by function which follow the admin automatically.

It will seem as if I was speaking to oneself with tremendous momentum...