### PR TITLE
Add feature to change compose form background depending on the privacy setting

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -48,6 +48,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
     onKeyDown: PropTypes.func,
     onPaste: PropTypes.func.isRequired,
     autoFocus: PropTypes.bool,
+    privacy: PropTypes.string,
   };
 
   static defaultProps = {
@@ -192,7 +193,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
   }
 
   render () {
-    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, children } = this.props;
+    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, privacy, children } = this.props;
     const { suggestionsHidden } = this.state;
 
     return [
@@ -203,7 +204,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
 
             <Textarea
               ref={this.setTextarea}
-              className='autosuggest-textarea__textarea'
+              className={`autosuggest-textarea__textarea autosuggest-textarea__textarea--${privacy}`}
               disabled={disabled}
               placeholder={placeholder}
               autoFocus={autoFocus}

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -216,7 +216,7 @@ class ComposeForm extends ImmutablePureComponent {
             onSuggestionSelected={this.onSpoilerSuggestionSelected}
             searchTokens={[':']}
             id='cw-spoiler-input'
-            className='spoiler-input__input'
+            className={`spoiler-input__input spoiler-input__input--${this.props.privacy}`}
           />
         </div>
 
@@ -234,11 +234,12 @@ class ComposeForm extends ImmutablePureComponent {
           onSuggestionSelected={this.onSuggestionSelected}
           onPaste={onPaste}
           autoFocus={!showSearch && !isMobile(window.innerWidth)}
+          privacy={this.props.privacy}
         >
           <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
-          <div className='compose-form__modifiers'>
+          <div className={`compose-form__modifiers compose-form__modifiers--${this.props.privacy}`}>
             <UploadFormContainer />
-            <PollFormContainer />
+            <PollFormContainer privacy={this.props.privacy} />
           </div>
         </AutosuggestTextarea>
 

--- a/app/javascript/mastodon/features/compose/components/poll_form.js
+++ b/app/javascript/mastodon/features/compose/components/poll_form.js
@@ -35,6 +35,7 @@ class Option extends React.PureComponent {
     onClearSuggestions: PropTypes.func.isRequired,
     onFetchSuggestions: PropTypes.func.isRequired,
     onSuggestionSelected: PropTypes.func.isRequired,
+    privacy: PropTypes.string,
     intl: PropTypes.object.isRequired,
   };
 
@@ -72,7 +73,7 @@ class Option extends React.PureComponent {
   }
 
   render () {
-    const { isPollMultiple, title, index, autoFocus, intl } = this.props;
+    const { isPollMultiple, title, index, autoFocus, privacy, intl } = this.props;
 
     return (
       <li>
@@ -98,6 +99,7 @@ class Option extends React.PureComponent {
             onSuggestionSelected={this.onSuggestionSelected}
             searchTokens={[':']}
             autoFocus={autoFocus}
+            className={`poll__textinput--${privacy}`}
           />
         </label>
 
@@ -126,6 +128,7 @@ class PollForm extends ImmutablePureComponent {
     onClearSuggestions: PropTypes.func.isRequired,
     onFetchSuggestions: PropTypes.func.isRequired,
     onSuggestionSelected: PropTypes.func.isRequired,
+    privacy: PropTypes.string,
     intl: PropTypes.object.isRequired,
   };
 
@@ -142,7 +145,7 @@ class PollForm extends ImmutablePureComponent {
   };
 
   render () {
-    const { options, expiresIn, isMultiple, onChangeOption, onRemoveOption, intl, ...other } = this.props;
+    const { options, expiresIn, isMultiple, onChangeOption, onRemoveOption, privacy, intl, ...other } = this.props;
 
     if (!options) {
       return null;
@@ -153,14 +156,14 @@ class PollForm extends ImmutablePureComponent {
     return (
       <div className='compose-form__poll-wrapper'>
         <ul>
-          {options.map((title, i) => <Option title={title} key={i} index={i} onChange={onChangeOption} onRemove={onRemoveOption} isPollMultiple={isMultiple} onToggleMultiple={this.handleToggleMultiple} autoFocus={i === autoFocusIndex} {...other} />)}
+          {options.map((title, i) => <Option title={title} key={i} index={i} onChange={onChangeOption} onRemove={onRemoveOption} isPollMultiple={isMultiple} onToggleMultiple={this.handleToggleMultiple} autoFocus={i === autoFocusIndex} privacy={privacy} {...other} />)}
         </ul>
 
         <div className='poll__footer'>
           <button disabled={options.size >= 4} className='button button-secondary' onClick={this.handleAddOption}><Icon id='plus' /> <FormattedMessage {...messages.add_option} /></button>
 
           {/* eslint-disable-next-line jsx-a11y/no-onchange */}
-          <select value={expiresIn} onChange={this.handleSelectDuration}>
+          <select value={expiresIn} onChange={this.handleSelectDuration} className={privacy}>
             <option value={300}>{intl.formatMessage(messages.minutes, { number: 5 })}</option>
             <option value={1800}>{intl.formatMessage(messages.minutes, { number: 30 })}</option>
             <option value={3600}>{intl.formatMessage(messages.hours, { number: 1 })}</option>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -459,6 +459,22 @@
     border: 0;
     outline: 0;
 
+    &--public {
+      background: $compose-form-public-color;
+    }
+
+    &--unlisted {
+      background: $compose-form-unlisted-color;
+    }
+
+    &--private {
+      background: $compose-form-private-color;
+    }
+
+    &--direct {
+      background: $compose-form-direct-color;
+    }
+
     &::placeholder {
       color: $dark-text-color;
     }
@@ -486,6 +502,22 @@
 
     &::-webkit-scrollbar {
       all: unset;
+    }
+
+    background-position: bottom 0px center;
+    background-size: 20%;
+    background-repeat: no-repeat;
+
+    &--unlisted {
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) / Add fill color and opacity --><path fill="%23000000" fill-opacity="0.04" d="M400 256H152V152.9c0-39.6 31.7-72.5 71.3-72.9 40-.4 72.7 32.1 72.7 72v16c0 13.3 10.7 24 24 24h32c13.3 0 24-10.7 24-24v-16C376 68 307.5-.3 223.5 0 139.5.3 72 69.5 72 153.5V256H48c-26.5 0-48 21.5-48 48v160c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z" /></svg>');
+    }
+
+    &--private {
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) / Add fill color and opacity --><path fill="%23000000" fill-opacity="0.04" d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"/></svg>');
+    }
+
+    &--direct {
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!-- Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) / Add fill color and opacity --><path fill="%23000000" fill-opacity="0.04" d="M502.3 190.8c3.9-3.1 9.7-.2 9.7 4.7V400c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V195.6c0-5 5.7-7.8 9.7-4.7 22.4 17.4 52.1 39.5 154.1 113.6 21.1 15.4 56.7 47.8 92.2 47.6 35.7.3 72-32.8 92.3-47.6 102-74.1 131.6-96.3 154-113.7zM256 320c23.2.4 56.6-29.2 73.4-41.4 132.7-96.3 142.8-104.7 173.4-128.7 5.8-4.5 9.2-11.5 9.2-18.9v-19c0-26.5-21.5-48-48-48H48C21.5 64 0 85.5 0 112v19c0 7.4 3.4 14.3 9.2 18.9 30.6 23.9 40.7 32.4 173.4 128.7 16.8 12.2 50.2 41.8 73.4 41.4z"/></svg>');
     }
 
     @media screen and (max-width: 600px) {
@@ -582,6 +614,22 @@
     font-family: inherit;
     font-size: 14px;
     background: $simple-background-color;
+
+    &--public {
+      background: $compose-form-public-color;
+    }
+
+    &--unlisted {
+      background: $compose-form-unlisted-color;
+    }
+
+    &--private {
+      background: $compose-form-private-color;
+    }
+
+    &--direct {
+      background: $compose-form-direct-color;
+    }
 
     .compose-form__upload-wrapper {
       overflow: hidden;

--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -89,6 +89,24 @@
       &:focus {
         border-color: $highlight-text-color;
       }
+
+      &.poll__textinput {
+        &--public {
+          background: $compose-form-public-color;
+        }
+
+        &--unlisted {
+          background: $compose-form-unlisted-color;
+        }
+
+        &--private {
+          background: $compose-form-private-color;
+        }
+
+        &--direct {
+          background: $compose-form-direct-color;
+        }
+      }
     }
 
     &.selectable {
@@ -214,6 +232,22 @@
 
       &:focus {
         border-color: $highlight-text-color;
+      }
+
+      &.public {
+        background-color: $compose-form-public-color;
+      }
+
+      &.unlisted{
+        background-color: $compose-form-unlisted-color;
+      }
+
+      &.private {
+        background-color: $compose-form-private-color;
+      }
+
+      &.direct{
+        background-color: $compose-form-direct-color;
       }
     }
   }

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -56,3 +56,9 @@ $no-gap-breakpoint: 415px;
 $font-sans-serif: 'mastodon-font-sans-serif' !default;
 $font-display: 'mastodon-font-display' !default;
 $font-monospace: 'mastodon-font-monospace' !default;
+
+// Variables for compose form
+$compose-form-public-color: $simple-background-color;
+$compose-form-unlisted-color: #ffffe7;
+$compose-form-private-color: #ffefe7;
+$compose-form-direct-color: $compose-form-private-color;


### PR DESCRIPTION
Change color and show icon in the compose form depending on the privacy setting.

- Set background color to yellow and show unlock icon if privacy is set to unlisted.
- Set background color to red and show lock icon if privacy is set to private.
- Set background color to red and show envelope icon if privacy is set to direct.