### PR TITLE
Enabled feature full-text search

### DIFF
--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -3,6 +3,11 @@
 class PublicStatusesIndex < Chewy::Index
   settings index: index_preset(refresh_interval: '30s', number_of_shards: 5), analysis: {
     filter: {
+      kuromoji_search_split: {
+        type: 'sudachi_split',
+        mode: 'search',
+      },
+
       english_stop: {
         type: 'stop',
         stopwords: '_english_',
@@ -19,6 +24,14 @@ class PublicStatusesIndex < Chewy::Index
       },
     },
 
+    tokenizer: {
+      sudachi_tokenizer: {
+        type: 'sudachi_tokenizer',
+        discard_punctuation: true,
+        additional_settings: '{"systemDict": "system_full.dic"}',
+      },
+    },
+
     analyzer: {
       verbatim: {
         tokenizer: 'uax_url_email',
@@ -26,15 +39,15 @@ class PublicStatusesIndex < Chewy::Index
       },
 
       content: {
-        tokenizer: 'standard',
+        tokenizer: 'sudachi_tokenizer',
         filter: %w(
           lowercase
           asciifolding
           cjk_width
-          elision
-          english_possessive_stemmer
-          english_stop
-          english_stemmer
+          kuromoji_search_split
+          sudachi_part_of_speech
+          sudachi_ja_stop
+          sudachi_normalizedform
         ),
       },
 

--- a/app/chewy/statuses_index.rb
+++ b/app/chewy/statuses_index.rb
@@ -3,6 +3,11 @@
 class StatusesIndex < Chewy::Index
   settings index: index_preset(refresh_interval: '30s', number_of_shards: 5), analysis: {
     filter: {
+      kuromoji_search_split: {
+        type: 'sudachi_split',
+        mode: 'search',
+      },
+
       english_stop: {
         type: 'stop',
         stopwords: '_english_',
@@ -19,6 +24,14 @@ class StatusesIndex < Chewy::Index
       },
     },
 
+    tokenizer: {
+      sudachi_tokenizer: {
+        type: 'sudachi_tokenizer',
+        discard_punctuation: true,
+        additional_settings: '{"systemDict": "system_full.dic"}',
+      },
+    },
+
     analyzer: {
       verbatim: {
         tokenizer: 'uax_url_email',
@@ -26,15 +39,15 @@ class StatusesIndex < Chewy::Index
       },
 
       content: {
-        tokenizer: 'standard',
+        tokenizer: 'sudachi_tokenizer',
         filter: %w(
           lowercase
           asciifolding
           cjk_width
-          elision
-          english_possessive_stemmer
-          english_stop
-          english_stemmer
+          kuromoji_search_split
+          sudachi_part_of_speech
+          sudachi_ja_stop
+          sudachi_normalizedform
         ),
       },
 


### PR DESCRIPTION
## install elasticsearch from elastic repository

```
# wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
# apt update
# apt install elasticsearch=8.8.1
```
take note the password of  superuser 'elastic' from display at the last of install.

hold elasticsearch version because sudachi force specify target elasticsearch version.

```
# apt-mark hold elasticsearch
```

see [document](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/deb.html)

## configuration elasticsearch

edit '/etc/elasticsearch/elasticsearch.yml' 

```yaml
cluster.name: some-name
node.name: ${HOSTNAME}
xpack.security.http.ssl.enabled: <depends on environment>
http.host: <depends on environment>
```

see [document](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/settings.html)

## create role and user

create role into `/etc/elasticsearch/roles.yml`.

```yaml
mastodon_full_access:
  cluster: [ 'monitor' ]
  indices:
    - names: [ '*' ]
      privileges: [ 'read', 'monitor', 'write', 'manage' ]
```

create user with command-line tool:

```
# sudo /usr/share/elasticsearch/bin/elasticsearch-users useradd mastodon -p <password> -r mastodon_full_access
```

see [document](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/defining-roles.html#roles-management-file)
see [document](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/users-command.html)
see [document](https://docs.joinmastodon.org/admin/elasticsearch/#security)

## start elasticsearch and confirm operation

```
# sudo systemctl start elasticsearch
```

and then confirm operation.

```
# curl -u 'elastic:<password>' http://localhost:9200/
```

see [document](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/deb.html#deb-check-running)

## setup elasticsearch-sudachi plug-in

install elasticsearch-sudachi.

```
# sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://github.com/WorksApplications/elasticsearch-sudachi/releases/download/v3.1.0/elasticsearch-8.8.1-analysis-sudachi-3.1.0.zip
```

install sudachi system dictionaries.

```
# mkdir /etc/elasticsearch/sudachi
# cd /etc/elasticsearch/sudachi
# wget wget https://github.com/WorksApplications/SudachiDict/releases/download/v20230927/sudachi-dictionary-20230927-core.zip
# wget wget https://github.com/WorksApplications/SudachiDict/releases/download/v20230927/sudachi-dictionary-20230927-full.zip
# unzip *zip
# rm *zip
```

note: even if set to use system_full.dic, system_core.dic probably required.

see [document](https://github.com/WorksApplications/elasticsearch-sudachi#installation)

## note
- elasticsearch v8 contains JRE
- probably sudachi.json is not necessary
    + sudachi-XX.jar contains all default settings
    + use `additional_settings` to override in index